### PR TITLE
add missing include for QPainterPath

### DIFF
--- a/FEBioStudio/PlotWidget.cpp
+++ b/FEBioStudio/PlotWidget.cpp
@@ -43,6 +43,7 @@ SOFTWARE.*/
 #include <QValidator>
 #include <QImage>
 #include <QFileDialog>
+#include <QPainterPath>
 #include <QRgb>
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Otherwise this causes the following error to appear

    PlotWidget.cpp: In member function 'void CPlotWidget::drawGrid(QPainter&)':
    PlotWidget.cpp:1328:18: error: aggregate 'QPainterPath path' has incomplete type and cannot be defined
     1328 |     QPainterPath path;
          |                  ^~~~
    PlotWidget.cpp:1346:18: error: aggregate 'QPainterPath path' has incomplete type and cannot be defined
     1346 |     QPainterPath path;
          |                  ^~~~
    PlotWidget.cpp: In member function 'void CPlotWidget::drawAxes(QPainter&)':
    PlotWidget.cpp:1370:17: error: aggregate 'QPainterPath xaxis' has incomplete type and cannot be defined
     1370 |    QPainterPath xaxis;
          |                 ^~~~~
    PlotWidget.cpp:1383:17: error: aggregate 'QPainterPath yaxis' has incomplete type and cannot be defined
     1383 |    QPainterPath yaxis;
          |                 ^~~~~

This was already discovered by @michaelrossherron  in this response to the issue #18 :
https://github.com/febiosoftware/FEBioStudio/issues/18#issuecomment-729229556

(I'm on Debian Sid with Qt 5.15.2+dfsg-4)

