### PR TITLE
Fixed FFmpeg depreciation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,11 +285,7 @@ if(MODEL_REPO)
 endif()
 
 if(USE_FFMPEG)
-    if(WIN32)
-        set(FFMPEG_LIB_NAMES avformat avcodec avutil swresample swscale)
-    else()
-        set(FFMPEG_LIB_NAMES avformat avcodec avresample avutil swresample swscale)
-    endif()
+    set(FFMPEG_LIB_NAMES avformat avcodec avutil swresample swscale)
     
     foreach(name IN LISTS FFMPEG_LIB_NAMES)
         findLib(FFMPEG_LIB_DIR FFMPEG_LIB ${name})

--- a/FEBioStudio/MPEGAnimation.h
+++ b/FEBioStudio/MPEGAnimation.h
@@ -53,7 +53,7 @@ public:
 protected:
     FILE *file; // a file pointer
     AVCodecContext *av_codec_context; // save the stream infomation
-    AVCodec *av_codec; // encoder
+    const AVCodec *av_codec; // encoder
     AVPacket av_packet; // all frames will be dumped into avpacket for muxing
     AVOutputFormat *av_output_format; // the output format for muxing
     AVFrame *rgb_frame;
@@ -64,6 +64,7 @@ protected:
     
 private:
     bool Rgb24ToYuv420p(QImage &im);
+    bool EncodeVideo(AVFrame *frame);
 
     int m_repeatFrames;
 };


### PR DESCRIPTION
Fixed depreciated FFmpeg functions, brought to version 6.0.

Explanation:
avpicture_fill is almost 1-1 to av_image_fill_arrays. 

avcodec_register_all is not required in newer versions, but wanted it to remain backwards compatible so I wrapped it in an if pre-processor statement checking ffmpeg version. 

avcodec_encode_video2 was depreciated to manually sending frames and receiving packets, I enclosed this functionality in another MPEGAnimation method, 'EncodeVideo', which should work as the encode video function did. To see an example I followed, see the following example file on ffmpeg's official documentation: https://ffmpeg.org/doxygen/6.0/encode_video_8c-example.html

My understanding is that except for avcodec_register_all, the functions I included are compatible with all versions of FFmpeg so backwards compatibility shouldn't be an issue regardless of version, but I tested with 6.1 and 3.4. 

In the CMakeLists file, I removed the "libavresample" requirement in the cmake file, this made the windows and unix the same so I deleted the if else block. 


Testing:
I built with both ffmpeg version 6.1 and 3.4 and had no problems starting, recording, pausing and outputting animations with either. No problems afterwards viewing, no signs of incorrectly outputted data or corruption. 