### PR TITLE
Added netgen paths and changed OCCT libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ if(CAD_FEATURES)
         endforeach(name)    
     endif()
 
-    set(OCCT_LIB_NAMES TKernel TKGeomBase TKTopAlgo TKPrim TKMesh TKMath TKBRep TKSTL TKFillet TKBO TKIGES TKSTEP TKSTEPBase TKXSBase TKG3d TKLCAF TKVCAF)
+    set(OCCT_LIB_NAMES TKernel TKGeomBase TKTopAlgo TKPrim TKMesh TKMath TKBRep TKFillet TKBO TKXSBase TKG3d TKLCAF TKVCAF TKDEIGES TKDESTEP TKDESTL)
     foreach(name IN LISTS OCCT_LIB_NAMES)
         findLib(OCCT_LIB_DIR OCCT_LIB ${name})
         list(APPEND OCCT_LIBS ${OCCT_LIB})

--- a/FindDependencies.cmake
+++ b/FindDependencies.cmake
@@ -232,11 +232,11 @@ if(WIN32)
 		DOC "Netgen library path")
 else()
   find_path(NETGEN_INC include/occgeom.hpp
-        PATHS $ENV{HOME}/* $ENV{HOME}/*/* /usr/local/x86_64/Contents/Resources/include /opt/netgen* /Applications/Netgen.app
+        PATHS $ENV{HOME}/* $ENV{HOME}/*/* /usr/local/x86_64/Contents/Resources/include /opt/netgen* /Applications/Netgen.app /usr/include/*
         PATH_SUFFIXES "include" "netgen/include" "build" "build/include" "occ" "Contents/Resources/include"
     DOC "Netgen include directory")
 	find_library(NETGEN_LIB nglib
-        PATHS /opt/netgen* $ENV{HOME}/* $ENV{HOME}/*/* /Applications/Netgen.app
+        PATHS /opt/netgen* $ENV{HOME}/* $ENV{HOME}/*/* /Applications/Netgen.app /usr/lib/*
         PATH_SUFFIXES "lib" "netgen/lib" "build" "build/lib" "Release" "Debug" "MacOS" "Contents/MacOS"
 		DOC "Netgen library path")
 endif()


### PR DESCRIPTION
Netgen:
On my machine, netgen couldn't be found so I added a search path that works for me and should work for some more linux machines. For libraries, /usr/lib/* and for the headers /usr/include/* in FindDependencies.cmake

OpenCascade:
A newer version of OCC (this was with 7.8.1) didn't remove functionality that FEBioStudio was using (as far as I can tell), but moved some of it around in the libraries. Specifically: TKSTL, TKIGES, TKSTEP, TKSTEPBase were removed and replaced by: TKDEIGES,  TKDESTEP and TKDESTL in CMakeLists.txt

**Testing**
- Building
Program was successfully built with my version of OCC. It may be important to note that the newest version of OCC is 7.9.0. If the maintainers would like, I could build that version to test as well.

- Running
I was able to successfully: 
1. import a STEP file, BREP file, an IGES file created in freeCAD
2. Generate the box and bottle OCC objects from the create panel 
3. Merge the box and bottle OCC objects together
4. Save the model
5. Reload the model
6. Edit the bottle and box position

Best I can tell, this encompasses all the functionality provided by OCC.


- Problems
I did encounter the following problems that seem to not be related to the OCC version as they failed with the release version of FEBioStudio, but I could be wrong and am missing something. 
1. If I merged two OCC boxes together, they would combine into one box and shift to the origin
2. I was unable to mesh the OCC objects generated in FEBioStudio, but i was able to mesh a simple cube I imported from FreeCAD

I can submit an issue for these things